### PR TITLE
Updated Dockerfile - included alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,9 @@ RUN apk --no-cache add --virtual .build-deps git make build-base && \
   cd $GOPATH/src/github.com/loadimpact/k6 && \
   rice append --exec=$GOPATH/bin/k6 -i ./js/compiler -i ./js/lib
 
-FROM scratch
+FROM alpine
 WORKDIR /root/
 COPY --from=builder /go/bin/k6 /root
 COPY --from=builder /etc/ssl /etc/ssl
+ENV PATH "$PATH:/root"
 ENTRYPOINT ["./k6"]


### PR DESCRIPTION
Changes required to have easy configuration of k6 in CI, particularly in gitlab.
Why:
1) gitlab require to have `script` section in yml. https://docs.gitlab.com/ce/ci/docker/using_docker_images.html#overriding-the-entrypoint-of-an-image
2) then "The Runner sends the script to the container's shell STDIN and receives the output.". shell STDIN is key message here
3) in k6 docker image there is from scratch section -> means that container is empty except k6 in it. No shell no nothing. So nothing to be used in gitlab script